### PR TITLE
I18n translations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 ﻿CKEditor 4 Changelog
 ====================
 
+## CKEditor 4.11.4.5
+
+Fixes:
+
+- [#6](https://github.com/interviewstreet/ckeditor-dev/pull/6/files): Fixed: Internationalization changes
+ - Changed the translation for label 'ok' in fr-ca
+ - Add fr-ca lang to codesnippet plugin
+ - Read the language value from window.__codesnippet__.lang in codesnippet plugin
+
 ## CKEditor 4.11.4.4
 
 Fixes:

--- a/lang/fr-ca.js
+++ b/lang/fr-ca.js
@@ -55,7 +55,7 @@ CKEDITOR.lang[ 'fr-ca' ] = {
 		cssClass: 'Classes CSS',
 		advisoryTitle: 'Titre',
 		cssStyle: 'Style',
-		ok: 'OK',
+		ok: 'Continuer',
 		cancel: 'Annuler',
 		close: 'Fermer',
 		preview: 'Aperçu',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor-dev",
-	"version": "4.11.4.4",
+	"version": "4.11.4.5",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs": "0.4.3",

--- a/plugins/codesnippet/lang/fr-ca.js
+++ b/plugins/codesnippet/lang/fr-ca.js
@@ -1,0 +1,13 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+ CKEDITOR.plugins.setLang( 'codesnippet', 'fr-ca', {
+	button: 'Insérer un extrait de code',
+	codeContents: 'Contenu des code',
+	emptySnippetError: 'Un extrait de code ne peut pas être vide.',
+	language: 'Langage',
+	title: 'Extrait de code',
+	pathName: 'code snippet 11'
+} );

--- a/plugins/codesnippet/plugin.js
+++ b/plugins/codesnippet/plugin.js
@@ -14,7 +14,7 @@
 
 	CKEDITOR.plugins.add( 'codesnippet', {
 		requires: 'widget,dialog',
-		lang: 'en', // %REMOVE_LINE_CORE%
+		lang: (window.__codesnippet__ && window.__codesnippet__.lang) || 'en', // %REMOVE_LINE_CORE%
 		icons: 'codesnippet', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%
 


### PR DESCRIPTION
Summary

- Changed the translation for label 'ok' in fr-ca
 - Add fr-ca lang to codesnippet plugin
 - Read the language value from `window.__codesnippet__.lang` in codesnippet plugin